### PR TITLE
[FEAT] 실패 데이터 재배치 및 중단 배치 재개 API

### DIFF
--- a/src/main/java/com/mycom/myapp/sendapp/SendappApplication.java
+++ b/src/main/java/com/mycom/myapp/sendapp/SendappApplication.java
@@ -3,11 +3,13 @@ package com.mycom.myapp.sendapp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
 @ConfigurationPropertiesScan
+@EnableAsync
 public class SendappApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mycom/myapp/sendapp/batch/calculator/SubscriptionSegmentCalculator.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/calculator/SubscriptionSegmentCalculator.java
@@ -180,11 +180,11 @@ public class SubscriptionSegmentCalculator {
                                     10,                                   // 소수점 자리수 (Scale, 넉넉하게 설정)
                                     RoundingMode.HALF_DOWN                  // 반내림 모드 (필수)
                             );
-                    if(cur.getUsersId() % 100 == 0) {
-                        String categoryName = (cur.getSubscribeCategoryId() == 1 ? "요금제" : "기타요금제");
-                        log.info("정산 실패. 회원 식별자: {}, 원천 카테고리: {}, 원천 식별자: {}", cur.getUsersId(), categoryName, cur.getSubscribeBillingHistoryId());
-                        throw new RuntimeException("정산 배치 실패 예외 처리 테스트용 예외 발생");
-                    }
+//                    if(cur.getUsersId() % 100 == 0) {
+//                        String categoryName = (cur.getSubscribeCategoryId() == 1 ? "요금제" : "기타요금제");
+//                        log.info("정산 실패. 회원 식별자: {}, 원천 카테고리: {}, 원천 식별자: {}", cur.getUsersId(), categoryName, cur.getSubscribeBillingHistoryId());
+//                        throw new RuntimeException("정산 배치 실패 예외 처리 테스트용 예외 발생");
+//                    }
                     // 최종 정산 결과에 대해 명시적 반내림 적용
                     Long originAmount = BigDecimal.valueOf(cur.getOriginAmount())
                             .multiply(usageRate).setScale(0, RoundingMode.DOWN).longValue();

--- a/src/main/java/com/mycom/myapp/sendapp/batch/calculator/SubscriptionSegmentCalculator.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/calculator/SubscriptionSegmentCalculator.java
@@ -5,6 +5,7 @@ import com.mycom.myapp.sendapp.batch.dto.MonthlyInvoiceRowDto;
 import com.mycom.myapp.sendapp.batch.dto.SubscribeBillingHistoryRowDto;
 import com.mycom.myapp.sendapp.batch.dto.SubscriptionSegmentDto;
 import com.mycom.myapp.sendapp.batch.enums.ServiceCategory;
+import com.mycom.myapp.sendapp.batch.support.BatchInvoiceProperties;
 import com.mycom.myapp.sendapp.batch.support.CategoryIdRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class SubscriptionSegmentCalculator {
     private final CategoryIdRegistry categoryIdRegistry;
+    private final BatchInvoiceProperties batchInvoiceProperties;
 
     /**
      * chunk 단위 구독 원천 데이터(rows)를 받아 세그먼트 목록을 생성합니다.
@@ -112,6 +114,8 @@ public class SubscriptionSegmentCalculator {
 
         int monthLength = periodStart.lengthOfMonth(); // 해당 년월의 일수
 
+        int failureWeight = batchInvoiceProperties.getFailureWeight();
+
         int addonCategoryId = categoryIdRegistry.getCategoryId(ServiceCategory.ADDON);
         boolean isPlanSettlementSuccess = true;
         for (int i = 0; i < buffer.size(); i++) {
@@ -180,11 +184,11 @@ public class SubscriptionSegmentCalculator {
                                     10,                                   // 소수점 자리수 (Scale, 넉넉하게 설정)
                                     RoundingMode.HALF_DOWN                  // 반내림 모드 (필수)
                             );
-//                    if(cur.getUsersId() % 100 == 0) {
-//                        String categoryName = (cur.getSubscribeCategoryId() == 1 ? "요금제" : "기타요금제");
-//                        log.info("정산 실패. 회원 식별자: {}, 원천 카테고리: {}, 원천 식별자: {}", cur.getUsersId(), categoryName, cur.getSubscribeBillingHistoryId());
-//                        throw new RuntimeException("정산 배치 실패 예외 처리 테스트용 예외 발생");
-//                    }
+                    if(failureWeight > 0 && cur.getUsersId() % failureWeight == 0) {
+                        String categoryName = (cur.getSubscribeCategoryId() == 1 ? "요금제" : "기타요금제");
+                        log.info("정산 실패. 회원 식별자: {}, 원천 카테고리: {}, 원천 식별자: {}", cur.getUsersId(), categoryName, cur.getSubscribeBillingHistoryId());
+                        throw new RuntimeException("정산 배치 실패 예외 처리 테스트용 예외 발생");
+                    }
                     // 최종 정산 결과에 대해 명시적 반내림 적용
                     Long originAmount = BigDecimal.valueOf(cur.getOriginAmount())
                             .multiply(usageRate).setScale(0, RoundingMode.DOWN).longValue();

--- a/src/main/java/com/mycom/myapp/sendapp/batch/config/MonthlyInvoiceForceBatchJobConfig.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/config/MonthlyInvoiceForceBatchJobConfig.java
@@ -1,0 +1,62 @@
+package com.mycom.myapp.sendapp.batch.config;
+
+import com.mycom.myapp.sendapp.batch.listener.MonthlyInvoiceAttemptListener;
+import com.mycom.myapp.sendapp.batch.tasklet.ForceAttemptStartTasklet;
+import com.mycom.myapp.sendapp.batch.writer.MonthlyInvoiceWriter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * 중단된 정산 배치를 강제 재개하는 Job 설정
+ * - Step0: ForceAttemptStartTasklet (attemptId/targetYyyymm 컨텍스트 세팅)
+ * - Step1: 기존 settlement chunk(step1SettlementChunk)와 동일한 로직 사용
+ */
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyInvoiceForceBatchJobConfig {
+    private final org.springframework.batch.core.repository.JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final ForceAttemptStartTasklet forceAttemptStartTasklet;
+    private final MonthlyInvoiceAttemptListener monthlyInvoiceAttemptListener;
+
+    // 기존 컴포넌트 재사용
+    private final JdbcPagingItemReader<com.mycom.myapp.sendapp.batch.dto.UserBillingDayDto> settlementTargetUserIdReader;
+    private final com.mycom.myapp.sendapp.batch.processor.InvoiceSettlementProcessor invoiceSettlementProcessor;
+    private final MonthlyInvoiceWriter monthlyInvoiceWriter;
+    private final com.mycom.myapp.sendapp.batch.support.BatchInvoiceProperties batchInvoiceProperties;
+
+    @Bean
+    public Job monthlyInvoiceSettlementForceJob() {
+        return new JobBuilder("monthlyInvoiceSettlementForceJob", jobRepository)
+                .start(forceStep0AttemptStart())
+                .next(forceStep1SettlementChunk())
+                .listener(monthlyInvoiceAttemptListener)
+                .build();
+    }
+
+    @Bean
+    public Step forceStep0AttemptStart() {
+        return new StepBuilder("forceStep0AttemptStart", jobRepository)
+                .tasklet(forceAttemptStartTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step forceStep1SettlementChunk() {
+        return new StepBuilder("forceStep1SettlementChunk", jobRepository)
+                .<com.mycom.myapp.sendapp.batch.dto.UserBillingDayDto, com.mycom.myapp.sendapp.batch.dto.MonthlyInvoiceRowDto>chunk(batchInvoiceProperties.getChunkSize(), transactionManager)
+                .reader(settlementTargetUserIdReader)
+                .processor(invoiceSettlementProcessor)
+                .writer(monthlyInvoiceWriter)
+                .listener(monthlyInvoiceAttemptListener)
+                .build();
+    }
+}

--- a/src/main/java/com/mycom/myapp/sendapp/batch/config/MonthlyInvoiceRetryBatchJobConfig.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/config/MonthlyInvoiceRetryBatchJobConfig.java
@@ -1,0 +1,85 @@
+package com.mycom.myapp.sendapp.batch.config;
+
+import com.mycom.myapp.sendapp.batch.listener.MonthlyInvoiceAttemptListener;
+import com.mycom.myapp.sendapp.batch.tasklet.RetrySettlementAttemptStartTasklet;
+import com.mycom.myapp.sendapp.batch.writer.MonthlyInvoiceRetryWriter;
+import com.mycom.myapp.sendapp.batch.support.BatchInvoiceProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.MySqlPagingQueryProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.Map;
+
+/**
+ * 정산 실패 재시도 배치 Job 설정
+ * - Reader: settlement_status에서 FAILED invoice_id 조회
+ * - Writer: monthly_invoice_batch_fail 기반으로 상세/합계 재반영
+ */
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyInvoiceRetryBatchJobConfig {
+    private final BatchInvoiceProperties batchInvoiceProperties;
+
+    private final org.springframework.batch.core.repository.JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final RetrySettlementAttemptStartTasklet retrySettlementAttemptStartTasklet;
+    private final MonthlyInvoiceAttemptListener monthlyInvoiceAttemptListener;
+    private final MonthlyInvoiceRetryWriter monthlyInvoiceRetryWriter;
+
+    @Bean
+    public Job monthlyInvoiceRetrySettlementJob(JdbcPagingItemReader<Long> failedSettlementInvoiceIdReader) {
+        return new JobBuilder("monthlyInvoiceRetrySettlementJob", jobRepository)
+                .start(retryStep0AttemptStart())
+                .next(retryStep1SettlementChunk(failedSettlementInvoiceIdReader))
+                .listener(monthlyInvoiceAttemptListener)
+                .build();
+    }
+
+    @Bean
+    public Step retryStep0AttemptStart() {
+        return new StepBuilder("retryStep0AttemptStart", jobRepository)
+                .tasklet(retrySettlementAttemptStartTasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Step retryStep1SettlementChunk(JdbcPagingItemReader<Long> failedSettlementInvoiceIdReader) {
+        return new StepBuilder("retryStep1SettlementChunk", jobRepository)
+                .<Long, Long>chunk(batchInvoiceProperties.getChunkSize(), transactionManager)
+                .reader(failedSettlementInvoiceIdReader)
+                .writer(monthlyInvoiceRetryWriter)
+                .listener(monthlyInvoiceAttemptListener)
+                .build();
+    }
+
+    @Bean
+    public JdbcPagingItemReader<Long> failedSettlementInvoiceIdReader(DataSource dataSource) {
+        MySqlPagingQueryProvider queryProvider = new MySqlPagingQueryProvider();
+        queryProvider.setSelectClause("SELECT invoice_id");
+        queryProvider.setFromClause("FROM settlement_status");
+        queryProvider.setWhereClause("WHERE status = 'FAILED'");
+        queryProvider.setSortKeys(Map.of("invoice_id", org.springframework.batch.item.database.Order.ASCENDING));
+
+        int pageSize = batchInvoiceProperties.getReaderPageSize();
+
+        return new JdbcPagingItemReaderBuilder<Long>()
+                .name("failedSettlementInvoiceIdReader")
+                .dataSource(dataSource)
+                .queryProvider(queryProvider)
+                .pageSize(pageSize)
+                .fetchSize(pageSize)
+                .rowMapper((rs, rowNum) -> rs.getLong("invoice_id"))
+                .saveState(true)
+                .build();
+    }
+}

--- a/src/main/java/com/mycom/myapp/sendapp/batch/controller/RetrySettlementBatchController.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/controller/RetrySettlementBatchController.java
@@ -22,4 +22,10 @@ public class RetrySettlementBatchController {
         JobExecution execution = batchService.runRetrySettlementBatch();
         return ResponseEntity.ok("retry batch started. executionId=" + execution.getId());
     }
+
+    @PostMapping("/settlement/resume")
+    public ResponseEntity<String> resumeStalledSettlement() {
+        JobExecution execution = batchService.resumeStalledSettlementBatch();
+        return ResponseEntity.ok("resume batch started. executionId=" + execution.getId());
+    }
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/controller/RetrySettlementBatchController.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/controller/RetrySettlementBatchController.java
@@ -1,0 +1,25 @@
+package com.mycom.myapp.sendapp.batch.controller;
+
+import com.mycom.myapp.sendapp.batch.service.BatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 정산 실패 재시도 배치 트리거용 API
+ */
+@RestController
+@RequestMapping("/api/batch")
+@RequiredArgsConstructor
+public class RetrySettlementBatchController {
+    private final BatchService batchService;
+
+    @PostMapping("/settlement/retry")
+    public ResponseEntity<String> retrySettlement() {
+        JobExecution execution = batchService.runRetrySettlementBatch();
+        return ResponseEntity.ok("retry batch started. executionId=" + execution.getId());
+    }
+}

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchAttemptDto.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchAttemptDto.java
@@ -21,4 +21,5 @@ public class MonthlyInvoiceBatchAttemptDto {
     private final Long successCount;
     private final Long failCount;
     private final String hostName;
+    private final Long targetCount;
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchAttemptRepository.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchAttemptRepository.java
@@ -51,4 +51,30 @@ public interface MonthlyInvoiceBatchAttemptRepository {
      * attempt 조회(필요 시)
      */
     Optional<MonthlyInvoiceBatchAttemptDto> findById(long attemptId);
+
+    /**
+     * 지정 시각 이전에 STARTED 상태로 남아있는 가장 오래된 attempt를 조회합니다.
+     */
+    Optional<MonthlyInvoiceBatchAttemptDto> findOldestStartedBefore(LocalDateTime cutoff);
+
+    /**
+     * 지정 시각 이후에 STARTED 상태 attempt가 존재하는지 확인합니다.
+     */
+    boolean existsStartedAfter(LocalDateTime cutoff);
+
+    /**
+     * STARTED → INTERRUPTED 로 상태 전환하면서 종료 시각/소요 시간을 기록합니다.
+     */
+    int markInterrupted(long attemptId, LocalDateTime endedAt, long durationMs);
+
+    /**
+     * FORCE 타입의 STARTED attempt를 생성합니다.
+     * - target_count/success_count/fail_count를 호출자가 지정한 값으로 채웁니다.
+     */
+    long insertForceStartedAttempt(int targetYyyymm,
+                                   long targetCount,
+                                   long successCount,
+                                   long failCount,
+                                   String hostName,
+                                   LocalDateTime startedAt);
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchExecutionStatus.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchExecutionStatus.java
@@ -6,5 +6,6 @@ package com.mycom.myapp.sendapp.batch.repository.attempt;
 public enum MonthlyInvoiceBatchExecutionStatus {
     STARTED,
     COMPLETED,
-    FAILED
+    FAILED,
+    INTERRUPTED
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchExecutionType.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/attempt/MonthlyInvoiceBatchExecutionType.java
@@ -6,5 +6,6 @@ package com.mycom.myapp.sendapp.batch.repository.attempt;
 public enum MonthlyInvoiceBatchExecutionType {
     SCHEDULED, // 정기 정산 배치
     MANUAL, // 수동 시작된 배치(관리자 기능)
-    FORCE // 배치 시작 선행 조건을 무시하고 강제 실행된 배치
+    FORCE, // 배치 시작 선행 조건을 무시하고 강제 실행된 배치
+    RETRY // 정산 실패분 재시도 배치
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/invoice/MonthlyInvoiceRepository.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/invoice/MonthlyInvoiceRepository.java
@@ -26,4 +26,10 @@ public interface MonthlyInvoiceRepository {
      * - invoice_id 기준 batch update
      */
     int[] batchUpdateTotals(List<MonthlyInvoiceRowDto> headers);
+
+    /**
+     * invoice_id 목록으로 월 청구서 헤더를 조회합니다.
+     * - totals, users_id, billing_yyyymm 등을 포함
+     */
+    List<MonthlyInvoiceRowDto> findByInvoiceIds(List<Long> invoiceIds);
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/micropayment/MicroPaymentBillingHistoryRepository.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/micropayment/MicroPaymentBillingHistoryRepository.java
@@ -19,4 +19,9 @@ public interface MicroPaymentBillingHistoryRepository {
             Long lastId,
             Integer limit
     );
+
+    /**
+     * PK 목록으로 단건 결제 원천 데이터를 조회합니다.
+     */
+    List<MicroPaymentBillingHistoryRowDto> findByIds(List<Long> billingHistoryIds);
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/micropayment/MicroPaymentBillingHistoryRepositoryImpl.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/micropayment/MicroPaymentBillingHistoryRepositoryImpl.java
@@ -81,4 +81,42 @@ public class MicroPaymentBillingHistoryRepositoryImpl implements MicroPaymentBil
                 .build(), args);
 
     }
+
+    @Override
+    public List<MicroPaymentBillingHistoryRowDto> findByIds(List<Long> billingHistoryIds) {
+        if (billingHistoryIds == null || billingHistoryIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String inClause = String.join(",", billingHistoryIds.stream().map(id -> "?").toArray(String[]::new));
+
+        String sql = String.format("""
+            SELECT
+                  micro_payment_billing_history_id,
+                  users_id,
+                  billing_yyyymm,
+                  micro_payment_service_id,
+                  service_name,
+                  origin_amount,
+                  discount_amount,
+                  total_amount,
+                  created_at
+            FROM micro_payment_billing_history
+            WHERE micro_payment_billing_history_id IN (%s)
+            """, inClause);
+
+        Object[] args = billingHistoryIds.toArray();
+
+        return jdbcTemplate.query(sql, (rs, rowNum) -> MicroPaymentBillingHistoryRowDto.builder()
+                .microPaymentBillingHistoryId(rs.getLong("micro_payment_billing_history_id"))
+                .usersId(rs.getLong("users_id"))
+                .billingYyyymm(rs.getInt("billing_yyyymm"))
+                .microPaymentServiceId(rs.getLong("micro_payment_service_id"))
+                .serviceName(rs.getString("service_name"))
+                .originAmount(rs.getLong("origin_amount"))
+                .discountAmount(rs.getLong("discount_amount"))
+                .totalAmount(rs.getLong("total_amount"))
+                .createdAt(rs.getTimestamp("created_at").toLocalDateTime())
+                .build(), args);
+    }
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/repository/settlement/InvoiceSettlementFailureRepository.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/repository/settlement/InvoiceSettlementFailureRepository.java
@@ -12,4 +12,14 @@ public interface InvoiceSettlementFailureRepository {
      * @return 총 반영(삽입)된 row 수
      */
     int[] batchInsert(List<MonthlyInvoiceBatchFailRowDto> rows);
+
+    /**
+     * invoice_id, invoice_category_id 조건으로 실패 원천 데이터를 조회합니다.
+     */
+    List<MonthlyInvoiceBatchFailRowDto> findByInvoiceIdsAndCategoryIds(List<Long> invoiceIds, List<Integer> categoryIds);
+
+    /**
+     * 단건 결제 카테고리 실패 원천 데이터를 fail_id 키셋으로 페이징 조회합니다.
+     */
+    List<MonthlyInvoiceBatchFailRowDto> findMicroByInvoiceIds(List<Long> invoiceIds, int microCategoryId, Long lastFailId, int limit);
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/scheduler/MonthlyInvoiceBatchScheduler.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/scheduler/MonthlyInvoiceBatchScheduler.java
@@ -8,6 +8,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -60,6 +61,7 @@ public class MonthlyInvoiceBatchScheduler {
     /**
      * 테스트 원천 데이터(2025년 10월) 정산 배치 수행 메서드(테스트용)
      */
+    @Async
     public void testMonthlyInvoiceBatch(Integer targetYyyymm) {
         if(targetYyyymm == null || targetYyyymm <= 0) {
             throw new IllegalArgumentException("정산 배치 테스트할 년월 정보를 올바르게 입력해주세요.");

--- a/src/main/java/com/mycom/myapp/sendapp/batch/service/BatchService.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/service/BatchService.java
@@ -2,13 +2,22 @@ package com.mycom.myapp.sendapp.batch.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.stereotype.Service;
+
+import com.mycom.myapp.sendapp.batch.repository.attempt.MonthlyInvoiceBatchAttemptDto;
+import com.mycom.myapp.sendapp.batch.repository.attempt.MonthlyInvoiceBatchAttemptRepository;
+import com.mycom.myapp.sendapp.batch.support.BatchClock;
+import com.mycom.myapp.sendapp.batch.support.HostIdentifier;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 
 @Service
 @Slf4j
@@ -17,6 +26,12 @@ public class BatchService {
     private final JobLauncher jobLauncher;
     @Qualifier("monthlyInvoiceRetrySettlementJob")
     private final Job monthlyInvoiceRetrySettlementJob;
+    @Qualifier("monthlyInvoiceSettlementForceJob")
+    private final Job monthlyInvoiceSettlementForceJob;
+
+    private final MonthlyInvoiceBatchAttemptRepository attemptRepository;
+    private final BatchClock batchClock;
+    private final HostIdentifier hostIdentifier;
 
     /**
      * 정산 실패 재시도 배치를 즉시 실행합니다.
@@ -34,6 +49,56 @@ public class BatchService {
         } catch (Exception e) {
             log.error("Failed to start retry settlement batch", e);
             throw new IllegalStateException("재시도 배치를 시작하지 못했습니다.", e);
+        }
+    }
+
+    /**
+     * 180분 이상 중단된 STARTED attempt를 INTERRUPTED로 마킹한 뒤 FORCE로 재시작합니다.
+     * - 가장 오래된 STARTED(180분 이상)만 재개
+     * - 180분 미만 STARTED가 존재하면 재개 불가
+     * - target_count/success_count/fail_count를 중단 attempt 값으로 복사해 새 attempt 시작
+     */
+    public JobExecution resumeStalledSettlementBatch() {
+        LocalDateTime now = batchClock.now();
+        LocalDateTime cutoff = now.minusMinutes(180);
+
+        // 180분 미만 STARTED가 있으면 재개하지 않음
+        if (attemptRepository.existsStartedAfter(cutoff)) {
+            throw new IllegalStateException("180분 미만 진행 중인 배치가 있어 재개할 수 없습니다.");
+        }
+
+        MonthlyInvoiceBatchAttemptDto stalled = attemptRepository.findOldestStartedBefore(cutoff)
+                .orElseThrow(() -> new IllegalStateException("중단된 배치를 찾을 수 없습니다."));
+
+        long durationMs = stalled.getStartedAt() == null ? 0L : Duration.between(stalled.getStartedAt(), now).toMillis();
+        int interrupted = attemptRepository.markInterrupted(stalled.getAttemptId(), now, durationMs);
+        if (interrupted == 0) {
+            throw new IllegalStateException("중단 attempt 상태 갱신에 실패했습니다. attemptId=" + stalled.getAttemptId());
+        }
+
+        long newAttemptId = attemptRepository.insertForceStartedAttempt(
+                stalled.getTargetYyyymm(),
+                stalled.getTargetCount() == null ? 0L : stalled.getTargetCount(),
+                stalled.getSuccessCount() == null ? 0L : stalled.getSuccessCount(),
+                stalled.getFailCount() == null ? 0L : stalled.getFailCount(),
+                hostIdentifier.get(),
+                now
+        );
+
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("targetYyyymm", String.valueOf(stalled.getTargetYyyymm()))
+                    .addLong("attemptId", newAttemptId)
+                    .addLong("runId", System.currentTimeMillis())
+                    .toJobParameters();
+
+            JobExecution execution = jobLauncher.run(monthlyInvoiceSettlementForceJob, params);
+            log.info("Force settlement batch started. executionId={}, attemptId={}, status={}",
+                    execution.getId(), newAttemptId, execution.getStatus());
+            return execution;
+        } catch (Exception e) {
+            log.error("Failed to resume stalled settlement batch", e);
+            throw new IllegalStateException("중단 배치 재개에 실패했습니다.", e);
         }
     }
 

--- a/src/main/java/com/mycom/myapp/sendapp/batch/service/BatchService.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/service/BatchService.java
@@ -1,0 +1,40 @@
+package com.mycom.myapp.sendapp.batch.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class BatchService {
+    private final JobLauncher jobLauncher;
+    @Qualifier("monthlyInvoiceRetrySettlementJob")
+    private final Job monthlyInvoiceRetrySettlementJob;
+
+    /**
+     * 정산 실패 재시도 배치를 즉시 실행합니다.
+     * - 별도 파라미터 없이 execution_type=RETRY attempt가 생성됩니다.
+     */
+    public JobExecution runRetrySettlementBatch() {
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("runId", System.currentTimeMillis()) // 재실행 시 중복 방지
+                    .toJobParameters();
+
+            JobExecution execution = jobLauncher.run(monthlyInvoiceRetrySettlementJob, params);
+            log.info("Retry settlement batch started. executionId={}, status={}", execution.getId(), execution.getStatus());
+            return execution;
+        } catch (Exception e) {
+            log.error("Failed to start retry settlement batch", e);
+            throw new IllegalStateException("재시도 배치를 시작하지 못했습니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/mycom/myapp/sendapp/batch/support/BatchInvoiceProperties.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/support/BatchInvoiceProperties.java
@@ -15,4 +15,5 @@ public class BatchInvoiceProperties {
     private final int microPageSize;
     private final int readerPageSize; // reader에서 한 번에 읽는 레코드 수
     private final int subDetailBatchSize; // 구독 상세 insert 레코드 수 단위
+    private final int failureWeight; // 정산 배치 실패 가중치(0 이하의 값이라면 가중치가 존재하지 않는 것으로 간주)
 }

--- a/src/main/java/com/mycom/myapp/sendapp/batch/tasklet/ForceAttemptStartTasklet.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/tasklet/ForceAttemptStartTasklet.java
@@ -1,0 +1,86 @@
+package com.mycom.myapp.sendapp.batch.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * 중단 배치 재개 시, 이미 생성된 attempt_id/targetYyyymm을 JobExecutionContext에 주입만 하는 Tasklet.
+ * - Guard를 우회하고 곧바로 Step1을 실행하기 위한 용도.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ForceAttemptStartTasklet implements Tasklet, StepExecutionListener {
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // no-op
+    }
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        StepExecution stepExecution = contribution.getStepExecution();
+        ExecutionContext jobCtx = stepExecution.getJobExecution().getExecutionContext();
+
+        Long attemptId = getLongParam(stepExecution, "attemptId");
+        Integer targetYyyymm = getIntParam(stepExecution, "targetYyyymm");
+
+        if (attemptId == null || targetYyyymm == null) {
+            throw new IllegalStateException("attemptId와 targetYyyymm JobParameter가 필요합니다.");
+        }
+
+        // 기존 정기 배치와 동일한 키로 저장하여 Writer/Processor가 활용하도록 한다.
+        jobCtx.putLong(MonthlyInvoiceAttemptStartTasklet.CTX_KEY_ATTEMPT_ID, attemptId);
+        jobCtx.putInt(MonthlyInvoiceAttemptStartTasklet.CTX_KEY_TARGET_YYYYMM, targetYyyymm);
+
+        log.info("Force attempt context set. attemptId={}, targetYyyymm={}", attemptId, targetYyyymm);
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        return ExitStatus.COMPLETED;
+    }
+
+    private Long getLongParam(StepExecution stepExecution, String key) {
+        if (stepExecution.getJobParameters() == null) return null;
+        var param = stepExecution.getJobParameters().getParameters().get(key);
+        if (param == null) return null;
+        Object value = param.getValue();
+        if (value instanceof Long l) return l;
+        if (value instanceof Integer i) return i.longValue();
+        if (value instanceof String s) {
+            try {
+                return Long.parseLong(s);
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Integer getIntParam(StepExecution stepExecution, String key) {
+        if (stepExecution.getJobParameters() == null) return null;
+        var param = stepExecution.getJobParameters().getParameters().get(key);
+        if (param == null) return null;
+        Object value = param.getValue();
+        if (value instanceof Integer i) return i;
+        if (value instanceof Long l) return l.intValue();
+        if (value instanceof String s) {
+            try {
+                return Integer.parseInt(s);
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mycom/myapp/sendapp/batch/tasklet/RetrySettlementAttemptStartTasklet.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/tasklet/RetrySettlementAttemptStartTasklet.java
@@ -1,0 +1,137 @@
+package com.mycom.myapp.sendapp.batch.tasklet;
+
+import com.mycom.myapp.sendapp.batch.repository.attempt.MonthlyInvoiceBatchExecutionStatus;
+import com.mycom.myapp.sendapp.batch.repository.attempt.MonthlyInvoiceBatchExecutionType;
+import com.mycom.myapp.sendapp.batch.support.BatchClock;
+import com.mycom.myapp.sendapp.batch.support.HostIdentifier;
+import com.mycom.myapp.sendapp.batch.tasklet.MonthlyInvoiceAttemptStartTasklet;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+/**
+ * 재시도 배치용 attempt 생성 Tasklet.
+ * - settlement_status.status=FAILED 대상 전체를 정산 대상으로 삼아 target_count에 기록
+ * - execution_type=RETRY 로 attempt 생성 후 attempt_id를 JobExecutionContext에 저장
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RetrySettlementAttemptStartTasklet implements Tasklet, StepExecutionListener {
+    public static final int RETRY_TARGET_YYYYMM = 0; // 다월 대상인 재시도 배치는 0으로 기록
+
+    private final JdbcTemplate jdbcTemplate;
+    private final BatchClock batchClock;
+    private final HostIdentifier hostIdentifier;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        // no-op
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRED)
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        StepExecution stepExecution = contribution.getStepExecution();
+        ExecutionContext jobCtx = stepExecution.getJobExecution().getExecutionContext();
+
+        // 이미 attempt_id가 있으면(재시작/중복 호출) 통과
+        if (jobCtx.containsKey(MonthlyInvoiceAttemptStartTasklet.CTX_KEY_ATTEMPT_ID)) {
+            return RepeatStatus.FINISHED;
+        }
+
+        // STARTED RETRY attempt 중복 실행 방지
+        assertRetryStartable();
+
+        long targetCount = countFailedSettlements();
+        LocalDateTime now = batchClock.now();
+        long attemptId = insertRetryAttempt(targetCount, now, hostIdentifier.get());
+
+        jobCtx.putLong(MonthlyInvoiceAttemptStartTasklet.CTX_KEY_ATTEMPT_ID, attemptId);
+        jobCtx.putInt(MonthlyInvoiceAttemptStartTasklet.CTX_KEY_TARGET_YYYYMM, RETRY_TARGET_YYYYMM);
+
+        log.info("Retry attempt created. attemptId={}, targetCount={}", attemptId, targetCount);
+        return RepeatStatus.FINISHED;
+    }
+
+    @Override
+    public org.springframework.batch.core.ExitStatus afterStep(StepExecution stepExecution) {
+        return org.springframework.batch.core.ExitStatus.COMPLETED;
+    }
+
+    private long countFailedSettlements() {
+        String sql = "SELECT COUNT(*) FROM settlement_status WHERE status = 'FAILED'";
+        Long count = jdbcTemplate.queryForObject(sql, Long.class);
+        return count == null ? 0L : count;
+    }
+
+    private void assertRetryStartable() {
+        String sql = """
+            SELECT attempt_id
+            FROM monthly_invoice_batch_attempt
+            WHERE execution_type = ?
+              AND execution_status = ?
+            LIMIT 1
+            FOR UPDATE
+            """;
+        Long existing = jdbcTemplate.query(sql,
+                rs -> rs.next() ? rs.getLong(1) : null,
+                MonthlyInvoiceBatchExecutionType.RETRY.name(),
+                MonthlyInvoiceBatchExecutionStatus.STARTED.name());
+
+        if (existing != null) {
+            throw new IllegalStateException("이미 진행 중인 RETRY 배치가 있습니다. attemptId=" + existing);
+        }
+    }
+
+    private long insertRetryAttempt(long targetCount, LocalDateTime startedAt, String hostName) {
+        String sql = """
+            INSERT INTO monthly_invoice_batch_attempt
+                (target_yyyymm, execution_status, execution_type, started_at, ended_at, duration_ms,
+                 success_count, fail_count, host_name, target_count)
+            VALUES
+                (?, ?, ?, ?, NULL, NULL,
+                 0, 0, ?, ?)
+            """;
+
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        int updated = jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            ps.setInt(1, RETRY_TARGET_YYYYMM);
+            ps.setString(2, MonthlyInvoiceBatchExecutionStatus.STARTED.name());
+            ps.setString(3, MonthlyInvoiceBatchExecutionType.RETRY.name());
+            ps.setTimestamp(4, Timestamp.valueOf(startedAt));
+            ps.setString(5, hostName);
+            ps.setLong(6, targetCount);
+            return ps;
+        }, keyHolder);
+
+        if (updated != 1) {
+            throw new IllegalStateException("RETRY attempt insert 실패. updatedRows=" + updated);
+        }
+
+        Number key = keyHolder.getKey();
+        if (key == null) {
+            throw new IllegalStateException("RETRY attempt_id를 반환받지 못했습니다. AUTO_INCREMENT 설정을 확인해주세요.");
+        }
+        return key.longValue();
+    }
+}

--- a/src/main/java/com/mycom/myapp/sendapp/batch/writer/MonthlyInvoiceRetryWriter.java
+++ b/src/main/java/com/mycom/myapp/sendapp/batch/writer/MonthlyInvoiceRetryWriter.java
@@ -1,0 +1,445 @@
+package com.mycom.myapp.sendapp.batch.writer;
+
+import com.mycom.myapp.sendapp.batch.calculator.SubscriptionSegmentCalculator;
+import com.mycom.myapp.sendapp.batch.dto.*;
+import com.mycom.myapp.sendapp.batch.enums.ServiceCategory;
+import com.mycom.myapp.sendapp.batch.enums.SettlementStatus;
+import com.mycom.myapp.sendapp.batch.repository.attempt.ChunkSettlementResultDto;
+import com.mycom.myapp.sendapp.batch.repository.attempt.MonthlyInvoiceBatchAttemptJdbcRepository;
+import com.mycom.myapp.sendapp.batch.repository.invoice.MonthlyInvoiceDetailRepository;
+import com.mycom.myapp.sendapp.batch.repository.invoice.MonthlyInvoiceRepository;
+import com.mycom.myapp.sendapp.batch.repository.micropayment.MicroPaymentBillingHistoryRepository;
+import com.mycom.myapp.sendapp.batch.repository.settlement.InvoiceSettlementFailureRepository;
+import com.mycom.myapp.sendapp.batch.repository.settlement.InvoiceSettlementStatusHistoryRepository;
+import com.mycom.myapp.sendapp.batch.repository.settlement.InvoiceSettlementStatusRepository;
+import com.mycom.myapp.sendapp.batch.repository.subscribe.SubscribeBillingHistoryRepository;
+import com.mycom.myapp.sendapp.batch.support.BatchInvoiceProperties;
+import com.mycom.myapp.sendapp.batch.support.CategoryIdRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 재시도 배치 Writer
+ * - settlement_status가 FAILED인 invoice_id들을 입력으로 받아, batch_fail 원천 데이터 기준으로 상세를 재생성
+ * - monthly_invoice totals는 “기존 값 + 재시도 생성 상세 값”으로 누적
+ * - 정산 상태가 성공하면 COMPLETED로 갱신, 실패 시 FAILED → FAILED history만 기록
+ */
+@Slf4j
+@StepScope
+@Component
+@RequiredArgsConstructor
+public class MonthlyInvoiceRetryWriter implements ItemWriter<Long> {
+    private final MonthlyInvoiceRepository monthlyInvoiceRepository;
+    private final MonthlyInvoiceDetailRepository monthlyInvoiceDetailRepository;
+
+    private final SubscribeBillingHistoryRepository subscribeBillingHistoryRepository;
+    private final SubscriptionSegmentCalculator subscriptionSegmentCalculator;
+
+    private final MicroPaymentBillingHistoryRepository microPaymentBillingHistoryRepository;
+
+    private final InvoiceSettlementFailureRepository failureRepository;
+    private final InvoiceSettlementStatusRepository settlementStatusRepository;
+    private final InvoiceSettlementStatusHistoryRepository settlementStatusHistoryRepository;
+    private final MonthlyInvoiceBatchAttemptJdbcRepository attemptRepository;
+
+    private final CategoryIdRegistry categoryIdRegistry;
+    private final BatchInvoiceProperties batchInvoiceProperties;
+
+    @Value("#{jobExecutionContext['monthlyInvoiceAttemptId']}")
+    private Long attemptId;
+
+    @Override
+    public void write(Chunk<? extends Long> chunk) {
+        if (chunk == null || chunk.isEmpty()) {
+            return;
+        }
+        if (attemptId == null) {
+            throw new IllegalArgumentException("jobExecutionContext['monthlyInvoiceAttemptId'] is required.");
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        List<Long> invoiceIds = chunk.getItems().stream()
+                .filter(Objects::nonNull)
+                .map(Long::valueOf)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Map<Long, MonthlyInvoiceRowDto> headerByInvoiceId = loadHeaders(invoiceIds);
+
+        // 존재하지 않는 invoice_id는 실패 처리
+        for (Long invoiceId : invoiceIds) {
+            headerByInvoiceId.computeIfAbsent(invoiceId, id ->
+                    MonthlyInvoiceRowDto.builder()
+                            .invoiceId(id)
+                            .settlementSuccess(false)
+                            .build()
+            );
+        }
+
+        int planCategoryId = categoryIdRegistry.getCategoryId(ServiceCategory.PLAN);
+        int etcPlanCategoryId = categoryIdRegistry.getCategoryId(ServiceCategory.ETC_PLAN);
+        int microCategoryId = categoryIdRegistry.getCategoryId(ServiceCategory.MICRO);
+
+        List<MonthlyInvoiceBatchFailRowDto> newFailRows = new ArrayList<>();
+        Set<Long> invoicesWithRetrySource = new HashSet<>();
+
+        // 3) 구독/요금제 실패 원천 재정산
+        List<MonthlyInvoiceBatchFailRowDto> subFails =
+                failureRepository.findByInvoiceIdsAndCategoryIds(invoiceIds, List.of(planCategoryId, etcPlanCategoryId));
+        if (!subFails.isEmpty()) {
+            invoicesWithRetrySource.addAll(subFails.stream()
+                    .map(MonthlyInvoiceBatchFailRowDto::getInvoiceId)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet()));
+            processSubscriptionFailures(headerByInvoiceId, subFails, newFailRows, now);
+        }
+
+        // 5) 단건 결제 실패 원천 재정산
+        invoicesWithRetrySource.addAll(processMicroFailures(headerByInvoiceId, invoiceIds, microCategoryId, newFailRows, now));
+
+        // 대상 invoice인데 실패 원천 자체가 없으면 실패 상태 유지
+        for (Long invoiceId : invoiceIds) {
+            if (!invoicesWithRetrySource.contains(invoiceId)) {
+                MonthlyInvoiceRowDto header = headerByInvoiceId.get(invoiceId);
+                if (header != null) {
+                    header.setSettlementSuccess(false);
+                }
+            }
+        }
+
+        // 실패 원천 기록 추가
+        if (!newFailRows.isEmpty()) {
+            failureRepository.batchInsert(newFailRows);
+        }
+
+        // 청구서 합계 갱신
+        List<MonthlyInvoiceRowDto> headersToUpdate = headerByInvoiceId.values().stream()
+                .filter(h -> h.getUsersId() != null) // 존재하는 헤더만 갱신
+                .toList();
+        if (!headersToUpdate.isEmpty()) {
+            monthlyInvoiceRepository.batchUpdateTotals(headersToUpdate);
+        }
+
+        // 정산 상태/이력 갱신
+        applyStatusAndHistory(invoiceIds, headerByInvoiceId, now);
+    }
+
+    private Map<Long, MonthlyInvoiceRowDto> loadHeaders(List<Long> invoiceIds) {
+        Map<Long, MonthlyInvoiceRowDto> map = new HashMap<>();
+        if (invoiceIds == null || invoiceIds.isEmpty()) {
+            return map;
+        }
+        List<MonthlyInvoiceRowDto> rows = monthlyInvoiceRepository.findByInvoiceIds(invoiceIds);
+        for (MonthlyInvoiceRowDto row : rows) {
+            if (row.getInvoiceId() == null) continue;
+            row.setSettlementSuccess(true); // 기본 성공 가정
+            map.put(row.getInvoiceId(), row);
+        }
+        return map;
+    }
+
+    private void processSubscriptionFailures(
+            Map<Long, MonthlyInvoiceRowDto> headerByInvoiceId,
+            List<MonthlyInvoiceBatchFailRowDto> failRows,
+            List<MonthlyInvoiceBatchFailRowDto> newFailRows,
+            LocalDateTime now
+    ) {
+        if (failRows == null || failRows.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Set<Long>> failIdsByInvoice = new HashMap<>();
+        for (MonthlyInvoiceBatchFailRowDto row : failRows) {
+            if (row.getInvoiceId() == null || row.getBillingHistoryId() == null) continue;
+            failIdsByInvoice.computeIfAbsent(row.getInvoiceId(), k -> new HashSet<>())
+                    .add(row.getBillingHistoryId());
+        }
+
+        Map<Integer, List<MonthlyInvoiceRowDto>> headersByYyyymm = headerByInvoiceId.values().stream()
+                .filter(h -> h.getBillingYyyymm() != null)
+                .filter(h -> failIdsByInvoice.containsKey(h.getInvoiceId()))
+                .collect(Collectors.groupingBy(MonthlyInvoiceRowDto::getBillingYyyymm));
+
+        for (Map.Entry<Integer, List<MonthlyInvoiceRowDto>> entry : headersByYyyymm.entrySet()) {
+            Integer yyyymm = entry.getKey();
+            List<MonthlyInvoiceRowDto> headers = entry.getValue();
+
+            List<Long> userIds = headers.stream()
+                    .map(MonthlyInvoiceRowDto::getUsersId)
+                    .filter(Objects::nonNull)
+                    .toList();
+
+            if (userIds.isEmpty()) {
+                continue;
+            }
+
+            Map<Long, MonthlyInvoiceRowDto> headerByUserId = headers.stream()
+                    .filter(h -> h.getUsersId() != null)
+                    .collect(Collectors.toMap(MonthlyInvoiceRowDto::getUsersId, Function.identity(), (a, b) -> a));
+
+            List<SubscribeBillingHistoryRowDto> raw =
+                    subscribeBillingHistoryRepository.findByUsersIdsAndYyyymm(yyyymm, userIds);
+
+            List<SubscriptionSegmentDto> segments =
+                    subscriptionSegmentCalculator.calculate(yyyymm, raw, newFailRows, attemptId, headerByUserId);
+
+            if (segments == null || segments.isEmpty()) {
+                continue;
+            }
+
+            List<MonthlyInvoiceDetailRowDto> buffer = new ArrayList<>(Math.min(segments.size(), batchInvoiceProperties.getSubDetailBatchSize()));
+
+            for (SubscriptionSegmentDto s : segments) {
+                MonthlyInvoiceRowDto header = headerByUserId.get(s.getUsersId());
+                if (header == null || header.getInvoiceId() == null) {
+                    continue;
+                }
+
+                Set<Long> targetFailIds = failIdsByInvoice.get(header.getInvoiceId());
+                if (targetFailIds == null || !targetFailIds.contains(s.getSubscribeBillingHistoryId())) {
+                    continue; // 이번 재시도 대상이 아닌 세그먼트
+                }
+
+                try {
+                    MonthlyInvoiceDetailRowDto d = MonthlyInvoiceDetailRowDto.builder()
+                            .detailId(null)
+                            .invoiceId(header.getInvoiceId())
+                            .invoiceCategoryId(s.getSubscribeCategoryId())
+                            .billingHistoryId(s.getSubscribeBillingHistoryId())
+                            .serviceName(s.getServiceName())
+                            .originAmount(nvl(s.getOriginAmount()))
+                            .discountAmount(nvl(s.getDiscountAmount()))
+                            .totalAmount(nvl(s.getTotalAmount()))
+                            .usageStartDate(s.getSegmentStartDate())
+                            .usageEndDate(s.getSegmentEndDate())
+                            .createdAt(now)
+                            .expiredAt(defaultExpiredAt(now))
+                            .build();
+
+                    buffer.add(d);
+                    if (buffer.size() >= batchInvoiceProperties.getSubDetailBatchSize()) {
+                        flushDetails(buffer, headerByInvoiceId, newFailRows, now);
+                    }
+                } catch (Exception ex) {
+                    header.setSettlementSuccess(false);
+                    newFailRows.add(buildFailRow("SUB_DETAIL_BUILD_FAIL", ex.getMessage(), now,
+                            s.getSubscribeCategoryId(), s.getSubscribeBillingHistoryId(), header.getInvoiceId()));
+                }
+            }
+
+            flushDetails(buffer, headerByInvoiceId, newFailRows, now);
+        }
+    }
+
+    private Set<Long> processMicroFailures(
+            Map<Long, MonthlyInvoiceRowDto> headerByInvoiceId,
+            List<Long> invoiceIds,
+            int microCategoryId,
+            List<MonthlyInvoiceBatchFailRowDto> newFailRows,
+            LocalDateTime now
+    ) {
+        Set<Long> invoicesWithMicro = new HashSet<>();
+        Long lastFailId = 0L;
+
+        while (true) {
+            List<MonthlyInvoiceBatchFailRowDto> microFails =
+                    failureRepository.findMicroByInvoiceIds(invoiceIds, microCategoryId, lastFailId, batchInvoiceProperties.getMicroPageSize());
+            if (microFails == null || microFails.isEmpty()) {
+                break;
+            }
+
+            invoicesWithMicro.addAll(microFails.stream()
+                    .map(MonthlyInvoiceBatchFailRowDto::getInvoiceId)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet()));
+
+            List<Long> billingIds = microFails.stream()
+                    .map(MonthlyInvoiceBatchFailRowDto::getBillingHistoryId)
+                    .filter(Objects::nonNull)
+                    .toList();
+
+            Map<Long, MicroPaymentBillingHistoryRowDto> rawById = microPaymentBillingHistoryRepository.findByIds(billingIds)
+                    .stream()
+                    .collect(Collectors.toMap(MicroPaymentBillingHistoryRowDto::getMicroPaymentBillingHistoryId, Function.identity()));
+
+            List<MonthlyInvoiceDetailRowDto> details = new ArrayList<>(microFails.size());
+
+            for (MonthlyInvoiceBatchFailRowDto fail : microFails) {
+                MonthlyInvoiceRowDto header = headerByInvoiceId.get(fail.getInvoiceId());
+                if (header == null || header.getInvoiceId() == null) {
+                    newFailRows.add(buildFailRow("INVOICE_NOT_FOUND", "missing header for invoice " + fail.getInvoiceId(),
+                            now, microCategoryId, fail.getBillingHistoryId(), fail.getInvoiceId()));
+                    continue;
+                }
+
+                MicroPaymentBillingHistoryRowDto raw = rawById.get(fail.getBillingHistoryId());
+                if (raw == null) {
+                    header.setSettlementSuccess(false);
+                    newFailRows.add(buildFailRow("MICRO_SOURCE_NOT_FOUND", "missing micro payment data",
+                            now, microCategoryId, fail.getBillingHistoryId(), fail.getInvoiceId()));
+                    continue;
+                }
+
+                try {
+                    MonthlyInvoiceDetailRowDto d = MonthlyInvoiceDetailRowDto.builder()
+                            .detailId(null)
+                            .invoiceId(header.getInvoiceId())
+                            .invoiceCategoryId(microCategoryId)
+                            .billingHistoryId(raw.getMicroPaymentBillingHistoryId())
+                            .serviceName(raw.getServiceName())
+                            .originAmount(nvl(raw.getOriginAmount()))
+                            .discountAmount(nvl(raw.getDiscountAmount()))
+                            .totalAmount(nvl(raw.getTotalAmount()))
+                            .usageStartDate(raw.getCreatedAt().toLocalDate())
+                            .usageEndDate(raw.getCreatedAt().toLocalDate())
+                            .createdAt(now)
+                            .expiredAt(defaultExpiredAt(now))
+                            .build();
+                    details.add(d);
+                } catch (Exception ex) {
+                    header.setSettlementSuccess(false);
+                    newFailRows.add(buildFailRow("MICRO_DETAIL_BUILD_FAIL", ex.getMessage(),
+                            now, microCategoryId, fail.getBillingHistoryId(), fail.getInvoiceId()));
+                }
+            }
+
+            flushDetails(details, headerByInvoiceId, newFailRows, now);
+
+            lastFailId = microFails.get(microFails.size() - 1).getFailId();
+        }
+
+        return invoicesWithMicro;
+    }
+
+    private void flushDetails(
+            List<MonthlyInvoiceDetailRowDto> details,
+            Map<Long, MonthlyInvoiceRowDto> headerByInvoiceId,
+            List<MonthlyInvoiceBatchFailRowDto> newFailRows,
+            LocalDateTime now
+    ) {
+        if (details == null || details.isEmpty()) {
+            return;
+        }
+
+        try {
+            int[] results = monthlyInvoiceDetailRepository.batchInsertIgnore(details);
+            for (int i = 0; i < results.length; i++) {
+                if (results[i] <= 0) {
+                    continue; // 이미 존재(IGNORE) → totals 증가시켜선 안 됨
+                }
+                MonthlyInvoiceDetailRowDto d = details.get(i);
+                MonthlyInvoiceRowDto header = headerByInvoiceId.get(d.getInvoiceId());
+                if (header != null) {
+                    addToHeaderTotals(header, d.getInvoiceCategoryId(), d.getOriginAmount(), d.getDiscountAmount(), d.getTotalAmount());
+                }
+            }
+        } catch (DataAccessException ex) {
+            log.error("monthly_invoice_detail batch insert 실패", ex);
+            for (MonthlyInvoiceDetailRowDto d : details) {
+                MonthlyInvoiceRowDto header = headerByInvoiceId.get(d.getInvoiceId());
+                if (header != null) {
+                    header.setSettlementSuccess(false);
+                }
+                newFailRows.add(buildFailRow("DETAIL_INSERT_FAIL", ex.getMessage(), now,
+                        d.getInvoiceCategoryId(), d.getBillingHistoryId(), d.getInvoiceId()));
+            }
+        } finally {
+            details.clear();
+        }
+    }
+
+    private void applyStatusAndHistory(
+            List<Long> invoiceIds,
+            Map<Long, MonthlyInvoiceRowDto> headerByInvoiceId,
+            LocalDateTime now
+    ) {
+        List<Long> successInvoiceIds = new ArrayList<>();
+        List<SettlementStatusHistoryRowDto> histories = new ArrayList<>(invoiceIds.size());
+
+        for (Long invoiceId : invoiceIds) {
+            MonthlyInvoiceRowDto header = headerByInvoiceId.get(invoiceId);
+            boolean success = header != null && Boolean.TRUE.equals(header.getSettlementSuccess());
+            if (success) {
+                successInvoiceIds.add(invoiceId);
+            }
+
+            histories.add(SettlementStatusHistoryRowDto.builder()
+                    .invoiceId(invoiceId)
+                    .attemptId(attemptId)
+                    .fromStatus(SettlementStatus.FAILED)
+                    .toStatus(success ? SettlementStatus.COMPLETED : SettlementStatus.FAILED)
+                    .changedAt(now)
+                    .reasonCode(success ? null : "retry failed")
+                    .build());
+        }
+
+        settlementStatusHistoryRepository.batchInsert(histories);
+
+        if (!successInvoiceIds.isEmpty()) {
+            settlementStatusRepository.batchUpdateStatus(successInvoiceIds, SettlementStatus.COMPLETED, now);
+        }
+
+        long successCount = successInvoiceIds.size();
+        long failCount = invoiceIds.size() - successCount;
+
+        ChunkSettlementResultDto dto = new ChunkSettlementResultDto();
+        dto.setSuccessCount(successCount);
+        dto.setFailCount(failCount);
+        attemptRepository.applyChunkResult(attemptId, dto);
+    }
+
+    private MonthlyInvoiceBatchFailRowDto buildFailRow(
+            String errorCode,
+            String errorMessage,
+            LocalDateTime now,
+            Integer invoiceCategoryId,
+            Long billingHistoryId,
+            Long invoiceId
+    ) {
+        return MonthlyInvoiceBatchFailRowDto.builder()
+                .attemptId(attemptId)
+                .errorCode(errorCode)
+                .errorMessage(errorMessage)
+                .createdAt(now)
+                .invoiceCategoryId(invoiceCategoryId)
+                .billingHistoryId(billingHistoryId)
+                .invoiceId(invoiceId)
+                .build();
+    }
+
+    private void addToHeaderTotals(MonthlyInvoiceRowDto header, int categoryId, Long origin, Long discount, Long total) {
+        header.setTotalDiscountAmount(nvl(header.getTotalDiscountAmount()) + nvl(discount));
+        header.setTotalAmount(nvl(header.getTotalAmount()) + nvl(total));
+
+        int planCategoryId = categoryIdRegistry.getCategoryId(ServiceCategory.PLAN);
+        int addonCategoryId = categoryIdRegistry.getCategoryId(ServiceCategory.ADDON);
+
+        if (categoryId == planCategoryId) {
+            header.setTotalPlanAmount(nvl(header.getTotalPlanAmount()) + nvl(origin));
+        } else if (categoryId == addonCategoryId) {
+            header.setTotalAddonAmount(nvl(header.getTotalAddonAmount()) + nvl(origin));
+        } else {
+            header.setTotalEtcAmount(nvl(header.getTotalEtcAmount()) + nvl(origin));
+        }
+    }
+
+    private Long nvl(Long v) {
+        return v == null ? 0L : v;
+    }
+
+    private LocalDate defaultExpiredAt(LocalDateTime now) {
+        return now.toLocalDate().plusYears(5);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,4 @@ app:
       reader-page-size: ${BATCH_INVOICE_READER_PAGE_SIZE:1000}
       micro-page-size: ${BATCH_INVOICE_MICRO_PAGE_SIZE:5000}
       sub-detail-batch-size: ${BATCH_INVOICE_SUB_DETAIL_BATCH_SIZE:5000}
+      failure-weight: ${BATCH_INVOICE_FAILURE_WEIGHT:-1}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

1. 정산 실패한 데이터에 대해 배치 수행하는 API
2. 중단된 배치를 다시 재개하는 API
3. 청크 및 페이지 크기 환경변수화
4. 원천 및 청구서 세부 카테고리 값을 배치 시작 직전 DB 조회한 값으로 사용하도록 설정

## 관련 이슈
<!---- 해당 PR과 관련된 이슈 번호가 있다면 작성해주세요. -->
<!---- Resolves: #39  -->

## PR 유형
<!-- 어떤 변경 사항이 있나요? -->

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
